### PR TITLE
Delete vault remove message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "mars-osmosis"
@@ -1118,7 +1118,7 @@ dependencies = [
 
 [[package]]
 name = "mars-params"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "mars-swapper"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "mars-swapper-base"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "mars-swapper-mock"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "mars-swapper-osmosis"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1300,9 +1300,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.5.0"
+version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "osmosis-std"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "1.0.5"
+version       = "1.0.6"
 authors       = [
   "Gabe R. <gabe.r@delphilabs.io>",
   "Larry Engineer <larry@delphidigital.io>",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,9 +18,9 @@ args = ["build", "--release", "--target", "wasm32-unknown-unknown", "--locked"]
 [tasks.rust-optimizer]
 script = """
 if [[ $(arch) == "arm64" ]]; then
-  image="cosmwasm/workspace-optimizer-arm64:0.12.11"
+  image="cosmwasm/workspace-optimizer-arm64:0.12.13"
 else
-  image="cosmwasm/workspace-optimizer:0.12.11"
+  image="cosmwasm/workspace-optimizer:0.12.13"
 fi
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \

--- a/contracts/params/src/execute.rs
+++ b/contracts/params/src/execute.rs
@@ -71,13 +71,6 @@ pub fn update_vault_config(
                 .add_attribute("action_type", "add_or_update")
                 .add_attribute("addr", checked.addr);
         }
-        VaultConfigUpdate::Remove {
-            addr,
-        } => {
-            let checked = deps.api.addr_validate(&addr)?;
-            VAULT_CONFIGS.remove(deps.storage, &checked);
-            response = response.add_attribute("action_type", "remove").add_attribute("addr", addr);
-        }
     }
 
     Ok(response)

--- a/contracts/params/src/msg.rs
+++ b/contracts/params/src/msg.rs
@@ -66,9 +66,6 @@ pub enum VaultConfigUpdate {
     AddOrUpdate {
         config: VaultConfigUnchecked,
     },
-    Remove {
-        addr: String,
-    },
 }
 
 #[cw_serde]

--- a/schemas/mars-params/mars-params.json
+++ b/schemas/mars-params/mars-params.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-params",
-  "contract_version": "1.0.5",
+  "contract_version": "1.0.6",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -504,27 +504,6 @@
                 "properties": {
                   "config": {
                     "$ref": "#/definitions/VaultConfigBase_for_String"
-                  }
-                },
-                "additionalProperties": false
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "object",
-            "required": [
-              "remove"
-            ],
-            "properties": {
-              "remove": {
-                "type": "object",
-                "required": [
-                  "addr"
-                ],
-                "properties": {
-                  "addr": {
-                    "type": "string"
                   }
                 },
                 "additionalProperties": false

--- a/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
+++ b/schemas/mars-swapper-osmosis/mars-swapper-osmosis.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-swapper-osmosis",
-  "contract_version": "1.0.5",
+  "contract_version": "1.0.6",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/scripts/types/generated/mars-params/MarsParams.types.ts
+++ b/scripts/types/generated/mars-params/MarsParams.types.ts
@@ -58,17 +58,11 @@ export type HlsAssetTypeForString =
       }
     }
 export type Uint128 = string
-export type VaultConfigUpdate =
-  | {
-      add_or_update: {
-        config: VaultConfigBaseForString
-      }
-    }
-  | {
-      remove: {
-        addr: string
-      }
-    }
+export type VaultConfigUpdate = {
+  add_or_update: {
+    config: VaultConfigBaseForString
+  }
+}
 export type EmergencyUpdate =
   | {
       credit_manager: CmEmergencyUpdate


### PR DESCRIPTION
This came up during the Gerhard audit. Removing assets/vault configs poses a kind of risk to protocols that rely upon them being there. If we find that something should be delisted, we should just update it to be whitelisted: false.